### PR TITLE
bugfix: Fix the NumPy version to 1.26.4, to avoid any issues with the…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi-slim==0.111.0
 fasttext==0.9.2
 uvicorn==0.30.1
+numpy==1.26.4


### PR DESCRIPTION
… new 2.0.0 version